### PR TITLE
fix: broken MIB translation unit tests

### DIFF
--- a/tests/test_translator.py
+++ b/tests/test_translator.py
@@ -78,7 +78,7 @@ class TranslatorTest(TestCase):
 
     @mongomock.patch()
     def setUp(self):
-        with open("./config.yaml", "r") as yamlfile:
+        with open("../config.yaml", "r") as yamlfile:
             server_config = yaml.load(yamlfile, Loader=yaml.FullLoader)
         server_config["snmp"]["mibs"]["dir"] = "../mibs/pysnmp"
         self.my_translator = Translator(server_config)


### PR DESCRIPTION
- config.yaml wasn't properly loaded (need to look to the parent's folder)